### PR TITLE
Stop using deprecated ym.hit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-yandex-metrica",
-  "version": "0.1.2",
+  "version": "0.1.3-check",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,9 +1,8 @@
-exports.onRouteUpdate = function ({ location }) {
+exports.onRouteUpdate = function ({ location }, {trackingId}) {
   if (process.env.NODE_ENV === `production` && typeof ym === `function`) {
     if (
       location &&
-      typeof window.ym !== `undefined` &&
-      typeof window.ym.hit === `function`
+      typeof window.ym !== `undefined`
     ) {
       return
     }
@@ -11,11 +10,11 @@ exports.onRouteUpdate = function ({ location }) {
     // wrap inside a timeout to make sure react-helmet is done with it's changes (https://github.com/gatsbyjs/gatsby/issues/9139)
     // reactHelmet is using requestAnimationFrame so we should use it too: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
     const sendPageView = () => {
-      window.ym.hit(
+      window.ym('hit', trackingId, (
         location
           ? location.pathname + location.search + location.hash
           : undefined
-      )
+      ))
     }
 
     if (`requestAnimationFrame` in window) {


### PR DESCRIPTION
`ym.hit` was [deprecated](https://yandex.ru/support/metrica/objects/hit.html?lang=en)

`ym('hit', "trackingId")` should be used instead.

Wasn't sure what was the logic [here](https://github.com/mellowjoey/gatsby-plugin-yandex-metrica/compare/master...agoldis:master#diff-0ac0069be12f75d163c0e0845c91963aL6)

It prevents tracking, but why? 